### PR TITLE
fix: add vercel deployed link to backend cors

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -41,6 +41,7 @@ def create_app() -> FastAPI:
         "http://localhost:3000",
         "http://localhost",
         "http://127.0.0.1:3000",
+        "https://surgence-mu.vercel.app"
     ]
 
     if settings.FRONTEND_URL:


### PR DESCRIPTION
- add https://surgence-mu.vercel.app to backend cors list